### PR TITLE
Replce some unsafe code with safe equivalents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,18 +1001,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.23"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.23"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ std = ["alloc"]
 use-intrinsics = []                         # Deprecated
 alloc = []
 rand_distr = ["dep:rand", "dep:rand_distr"]
+zerocopy = []
 
 [dependencies]
 cfg-if = "1.0.0"
@@ -31,9 +32,10 @@ serde = { version = "1.0", default-features = false, features = [
 num-traits = { version = "0.2.16", default-features = false, features = [
     "libm",
 ], optional = true }
-zerocopy = { version = "0.8.23", default-features = false, features = [
+zerocopy = { version = "0.8.26", default-features = false, features = [
     "derive",
-], optional = true }
+    "simd",
+] }
 rand = { version = "0.9.0", default-features = false, features = [
     "thread_rng",
 ], optional = true }

--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -19,7 +19,6 @@ use core::{
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "zerocopy")]
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub(crate) mod convert;
@@ -42,11 +41,8 @@ pub(crate) mod convert;
 )]
 #[cfg_attr(feature = "rkyv", rkyv(resolver = Bf16Resolver))]
 #[cfg_attr(feature = "bytemuck", derive(Zeroable, Pod))]
-#[cfg_attr(
-    feature = "zerocopy",
-    derive(FromBytes, Immutable, IntoBytes, KnownLayout)
-)]
 #[cfg_attr(kani, derive(kani::Arbitrary))]
+#[derive(FromBytes, Immutable, IntoBytes, KnownLayout)]
 pub struct bf16(u16);
 
 impl bf16 {

--- a/src/bfloat/convert.rs
+++ b/src/bfloat/convert.rs
@@ -1,11 +1,11 @@
 use crate::leading_zeros::leading_zeros_u16;
-use core::mem;
+use zerocopy::transmute;
 
 #[inline]
 pub(crate) const fn f32_to_bf16(value: f32) -> u16 {
-    // TODO: Replace mem::transmute with to_bits() once to_bits is const-stabilized
+    // TODO: Replace transmute with to_bits() once to_bits is const-stabilized
     // Convert to raw bytes
-    let x: u32 = unsafe { mem::transmute::<f32, u32>(value) };
+    let x: u32 = transmute!(value);
 
     // check for NaN
     if x & 0x7FFF_FFFFu32 > 0x7F80_0000u32 {
@@ -24,10 +24,10 @@ pub(crate) const fn f32_to_bf16(value: f32) -> u16 {
 
 #[inline]
 pub(crate) const fn f64_to_bf16(value: f64) -> u16 {
-    // TODO: Replace mem::transmute with to_bits() once to_bits is const-stabilized
+    // TODO: Replace transmute with to_bits() once to_bits is const-stabilized
     // Convert to raw bytes, truncating the last 32-bits of mantissa; that precision will always
     // be lost on half-precision.
-    let val: u64 = unsafe { mem::transmute::<f64, u64>(value) };
+    let val: u64 = transmute!(value);
     let x = (val >> 32) as u32;
 
     // Extract IEEE754 components
@@ -92,21 +92,21 @@ pub(crate) const fn f64_to_bf16(value: f64) -> u16 {
 
 #[inline]
 pub(crate) const fn bf16_to_f32(i: u16) -> f32 {
-    // TODO: Replace mem::transmute with from_bits() once from_bits is const-stabilized
+    // TODO: Replace transmute with from_bits() once from_bits is const-stabilized
     // If NaN, keep current mantissa but also set most significiant mantissa bit
     if i & 0x7FFFu16 > 0x7F80u16 {
-        unsafe { mem::transmute::<u32, f32>((i as u32 | 0x0040u32) << 16) }
+        transmute!((i as u32 | 0x0040u32) << 16)
     } else {
-        unsafe { mem::transmute::<u32, f32>((i as u32) << 16) }
+        transmute!((i as u32) << 16)
     }
 }
 
 #[inline]
 pub(crate) const fn bf16_to_f64(i: u16) -> f64 {
-    // TODO: Replace mem::transmute with from_bits() once from_bits is const-stabilized
+    // TODO: Replace transmute with from_bits() once from_bits is const-stabilized
     // Check for signed zero
     if i & 0x7FFFu16 == 0 {
-        return unsafe { mem::transmute::<u64, f64>((i as u64) << 48) };
+        return transmute!((i as u64) << 48);
     }
 
     let half_sign = (i & 0x8000u16) as u64;
@@ -117,16 +117,10 @@ pub(crate) const fn bf16_to_f64(i: u16) -> f64 {
     if half_exp == 0x7F80u64 {
         // Check for signed infinity if mantissa is zero
         if half_man == 0 {
-            return unsafe {
-                mem::transmute::<u64, f64>((half_sign << 48) | 0x7FF0_0000_0000_0000u64)
-            };
+            return transmute!((half_sign << 48) | 0x7FF0_0000_0000_0000u64);
         } else {
             // NaN, keep current mantissa but also set most significiant mantissa bit
-            return unsafe {
-                mem::transmute::<u64, f64>(
-                    (half_sign << 48) | 0x7FF8_0000_0000_0000u64 | (half_man << 45),
-                )
-            };
+            return transmute!((half_sign << 48) | 0x7FF8_0000_0000_0000u64 | (half_man << 45));
         }
     }
 
@@ -143,10 +137,10 @@ pub(crate) const fn bf16_to_f64(i: u16) -> f64 {
         // Rebias and adjust exponent
         let exp = ((1023 - 127 - e) as u64) << 52;
         let man = (half_man << (46 + e)) & 0xF_FFFF_FFFF_FFFFu64;
-        return unsafe { mem::transmute::<u64, f64>(sign | exp | man) };
+        return transmute!(sign | exp | man);
     }
     // Rebias exponent for a normalized normal
     let exp = ((unbiased_exp + 1023) as u64) << 52;
     let man = (half_man & 0x007Fu64) << 45;
-    unsafe { mem::transmute::<u64, f64>(sign | exp | man) }
+    transmute!(sign | exp | man)
 }

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -19,7 +19,6 @@ use core::{
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "zerocopy")]
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub(crate) mod arch;
@@ -41,12 +40,9 @@ pub(crate) mod arch;
 )]
 #[cfg_attr(feature = "rkyv", rkyv(resolver = F16Resolver))]
 #[cfg_attr(feature = "bytemuck", derive(Zeroable, Pod))]
-#[cfg_attr(
-    feature = "zerocopy",
-    derive(FromBytes, Immutable, IntoBytes, KnownLayout)
-)]
 #[cfg_attr(kani, derive(kani::Arbitrary))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(FromBytes, Immutable, IntoBytes, KnownLayout)]
 pub struct f16(u16);
 
 impl f16 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,8 +266,9 @@ pub mod prelude {
 // Keep this module private to crate
 mod private {
     use crate::{bf16, f16};
+    use zerocopy::{FromBytes, IntoBytes, Immutable};
 
-    pub trait SealedHalf {}
+    pub trait SealedHalf: FromBytes + IntoBytes + Immutable {}
 
     impl SealedHalf for f16 {}
     impl SealedHalf for bf16 {}

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -11,7 +11,7 @@ use crate::{bf16, binary16::arch, f16};
 #[cfg(feature = "alloc")]
 #[allow(unused_imports)]
 use alloc::{vec, vec::Vec};
-use core::slice;
+use zerocopy::{transmute_ref, transmute_mut};
 
 /// Extensions to `[f16]` and `[bf16]` slices to support conversion and reinterpret operations.
 ///
@@ -301,20 +301,12 @@ mod private {
 impl HalfFloatSliceExt for [f16] {
     #[inline]
     fn reinterpret_cast(&self) -> &[u16] {
-        let pointer = self.as_ptr() as *const u16;
-        let length = self.len();
-        // SAFETY: We are reconstructing full length of original slice, using its same lifetime,
-        // and the size of elements are identical
-        unsafe { slice::from_raw_parts(pointer, length) }
+        transmute_ref!(self)
     }
 
     #[inline]
     fn reinterpret_cast_mut(&mut self) -> &mut [u16] {
-        let pointer = self.as_mut_ptr().cast::<u16>();
-        let length = self.len();
-        // SAFETY: We are reconstructing full length of original slice, using its same lifetime,
-        // and the size of elements are identical
-        unsafe { slice::from_raw_parts_mut(pointer, length) }
+        transmute_mut!(self)
     }
 
     #[inline]
@@ -383,20 +375,12 @@ impl HalfFloatSliceExt for [f16] {
 impl HalfFloatSliceExt for [bf16] {
     #[inline]
     fn reinterpret_cast(&self) -> &[u16] {
-        let pointer = self.as_ptr() as *const u16;
-        let length = self.len();
-        // SAFETY: We are reconstructing full length of original slice, using its same lifetime,
-        // and the size of elements are identical
-        unsafe { slice::from_raw_parts(pointer, length) }
+        transmute_ref!(self)
     }
 
     #[inline]
     fn reinterpret_cast_mut(&mut self) -> &mut [u16] {
-        let pointer = self.as_mut_ptr().cast::<u16>();
-        let length = self.len();
-        // SAFETY: We are reconstructing full length of original slice, using its same lifetime,
-        // and the size of elements are identical
-        unsafe { slice::from_raw_parts_mut(pointer, length) }
+        transmute_mut!(self)
     }
 
     #[inline]
@@ -481,11 +465,7 @@ impl HalfBitsSliceExt for [u16] {
     where
         H: crate::private::SealedHalf,
     {
-        let pointer = self.as_ptr() as *const H;
-        let length = self.len();
-        // SAFETY: We are reconstructing full length of original slice, using its same lifetime,
-        // and the size of elements are identical
-        unsafe { slice::from_raw_parts(pointer, length) }
+        transmute_ref!(self)
     }
 
     #[inline]
@@ -493,11 +473,7 @@ impl HalfBitsSliceExt for [u16] {
     where
         H: crate::private::SealedHalf,
     {
-        let pointer = self.as_mut_ptr() as *mut H;
-        let length = self.len();
-        // SAFETY: We are reconstructing full length of original slice, using its same lifetime,
-        // and the size of elements are identical
-        unsafe { slice::from_raw_parts_mut(pointer, length) }
+        transmute_mut!(self)
     }
 }
 


### PR DESCRIPTION
Take zerocopy as a non-optional dependency. Add a zerocopy feature so that existing dependents which use the zerocopy feature won't fail to build.